### PR TITLE
Workaround for https://bugs.ruby-lang.org/issues/8182

### DIFF
--- a/lib/cobbler/connection/handling.rb
+++ b/lib/cobbler/connection/handling.rb
@@ -81,7 +81,9 @@ module Cobbler
                 # Returns a connection to the Cobbler server.
                 def connect
                     debug("Connecting to http://#{hostname}/cobbler_api")
-                    @connection = XMLRPC::Client.new2("http://#{hostname}/cobbler_api")
+                    @connection = XMLRPC::Client.new2("http://#{hostname}/cobbler_api").tap do |client|
+                        client.http_header_extra = { 'Accept-Encoding' => 'identity' }
+                    end
                 end
                 
                 private                


### PR DESCRIPTION
This sets the HTTP Accept-Encoding header to a permissive setting that works around the bug in ruby 2.x documented here:

 https://bugs.ruby-lang.org/issues/8182
