### PR TITLE
Fix Base inheritance

### DIFF
--- a/lib/cobbler/connection/handling.rb
+++ b/lib/cobbler/connection/handling.rb
@@ -20,6 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with rubygem-cobbler.  If not, see <http://www.gnu.org/licenses/>.
 
+require 'active_support/core_ext/module'
 require 'xmlrpc/client'
 
 # +Handling+ provides common methods to handle the xmlrpc connection to the 
@@ -36,7 +37,7 @@ module Cobbler
                 
                 # Set hostname, username, password for the Cobbler server, overriding any settings
                 # from cobbler.yml.
-                attr_accessor :hostname, :username, :password
+                cattr_accessor :hostname, :username, :password
                 
                 # Returns the version for the remote cobbler instance.
                 def remote_version


### PR DESCRIPTION
A fix, so that this works as expected:
# irb

> > require 'cobbler'
> > => true
> > cb = Cobbler::Base
> > => Cobbler::Base
> > cb.hostname = 'cobbler.example.com'
> > => "cobbler.example.com"
> > d = Cobbler::Distro
> > => Cobbler::Distro
> > d.hostname
> > => "cobbler.example.com"

Without this patch d.hostname is nil.
