### PR TITLE
Support for secure connections to cobbler XMLRPC

### DIFF
--- a/config/cobbler.yml
+++ b/config/cobbler.yml
@@ -3,3 +3,4 @@
 hostname: localhost
 username: cobbler
 password: cobbler
+secure: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,8 @@ end
 def with_real_cobbler(calzz,&blk)
     unless ENV['NO_REAL_COBBLER'] == '1'
         config = (ENV['COBBLER_YML'] || File.expand_path(File.join(File.dirname(__FILE__),'..','config','cobbler.yml')))
-        if File.exist?(config) && (yml = YAML::load(File.open(config))) && (yml['hostname'] && yml['username'] && yml['password'])
+        if File.exist?(config) && (yml = YAML::load(File.open(config))) && (yml['hostname'] && yml['username'] && \
+          yml['password'] && yml['secure'])
             yield(yml)
         else
             puts "No cobbler data found."


### PR DESCRIPTION
I needed to talk to cobbler server over SSL but as I'm using self-signed certificate it complained. This adds support for SSL over XMLRPC and ability to disable verification of peer certificates in case it's needed.
