### PR TITLE
Implement timeout parameter and add specs

### DIFF
--- a/config/cobbler.yml
+++ b/config/cobbler.yml
@@ -4,3 +4,4 @@ hostname: localhost
 username: cobbler
 password: cobbler
 secure: false
+timeout: 30

--- a/lib/cobbler/connection/handling.rb
+++ b/lib/cobbler/connection/handling.rb
@@ -37,7 +37,7 @@ module Cobbler
                 
                 # Set hostname, username, password for the Cobbler server, overriding any settings
                 # from cobbler.yml.
-                mattr_accessor :hostname, :username, :password, :secure, :verify_ssl
+                mattr_accessor :hostname, :username, :password, :secure, :verify_ssl, :timeout
                 
                 # Returns the version for the remote cobbler instance.
                 def remote_version
@@ -82,7 +82,7 @@ module Cobbler
                 # Returns a connection to the Cobbler server.
                 def connect
                     debug("Connecting to #{protocol}://#{hostname}/cobbler_api")
-                    @connection = XMLRPC::Client.new2("#{protocol}://#{hostname}/cobbler_api").tap do |client|
+                    @connection = XMLRPC::Client.new2("#{protocol}://#{hostname}/cobbler_api",nil,timeout).tap do |client|
                         client.http_header_extra = { 'Accept-Encoding' => 'identity' } if client.respond_to?(:http_header_extra=)
                         if secure && no_verify_ssl
                             client.instance_variable_get(:@http).instance_variable_set(:@verify_mode, OpenSSL::SSL::VERIFY_NONE)

--- a/lib/cobbler/system.rb
+++ b/lib/cobbler/system.rb
@@ -25,7 +25,7 @@
 module Cobbler
     class System < Base
         cobbler_fields :name, :profile, :image, :kickstart, :netboot_enabled, :server, :virt_cpus,
-        :virt_file_size, :virt_path, :virt_ram, :virt_auto_boot, :virt_type, :gateway, :hostname
+        :virt_file_size, :virt_path, :virt_ram, :virt_auto_boot, :virt_type, :gateway, :hostname, :timeout
 
         cobbler_collection :kernel_options, :packing => :hash
         cobbler_collection :ks_meta, :packing => :hash, :store => :store_ksmeta

--- a/spec/unit/cobbler/connection/common_spec.rb
+++ b/spec/unit/cobbler/connection/common_spec.rb
@@ -40,6 +40,7 @@ describe Cobbler::Connection::Common do
                 TestConnection.hostname = yml['hostname']
                 TestConnection.username = yml['username']
                 TestConnection.password = yml['password']
+                TestConnection.timeout = yml['timeout']
             end
             
             it "should "

--- a/spec/unit/cobbler/connection/handling_spec.rb
+++ b/spec/unit/cobbler/connection/handling_spec.rb
@@ -7,7 +7,7 @@ class TestConnection
 end
 
 describe Cobbler::Connection::Handling do
-    [:hostname, :username, :password].each do |field|
+    [:hostname, :username, :password, :timeout].each do |field|
         it "should provide getters and setters for #{field}" do
             TestConnection.should respond_to(field)
             TestConnection.should respond_to("#{field}=".to_sym)

--- a/spec/unit/cobbler/connection/handling_spec.rb
+++ b/spec/unit/cobbler/connection/handling_spec.rb
@@ -60,7 +60,7 @@ describe Cobbler::Connection::Handling do
     it "should connect to the cobbler server" do
         TestConnection.hostname = 'localhost'
         @connection = Object.new
-        XMLRPC::Client.expects(:new2).with('http://localhost/cobbler_api').returns(@connection)
+        XMLRPC::Client.expects(:new2).with('http://localhost/cobbler_api',nil,nil).returns(@connection)
         TestConnection.send(:connect)
     end
 


### PR DESCRIPTION
This Pull request adds support to the cobbler gem for the ```timeout``` parameter supported by the underlying XMLRPC::Client library it uses. The timeout will still default to 30 seconds as it did before if not specified, but for those cases where the 30 second timeout is not sufficient, this allows it to be increased.